### PR TITLE
Fix SHARIFF BACKEND TMPDIR

### DIFF
--- a/shariff/backend/index.php
+++ b/shariff/backend/index.php
@@ -38,22 +38,22 @@ class Application{
                                                         "6"=>"StumbleUpon",
                                                         "7"=>"Pinterest",
                                                         "8"=>"Xing");
+    // force a short init because we only need WP core
+    define( 'SHORTINIT', true );
+    // build the wp-load/-config.php path
+    $wp_root_path = dirname( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) );
+    // include the config
+    include ( $wp_root_path . '/wp-config.php' );         
+    // include wp-load.php file (that loads wp-config.php and bootstraps WP)
+    require( $wp_root_path . '/wp-load.php' );
+    // include for needed untrailingslashit()
+    require( $wp_root_path . '/wp-includes/formatting.php');
     // if we have a constant for the ttl (default is 60 s)
     if(defined('SHARIFF_BACKEND_TTL'))$tmp["cache"]["ttl"]=SHARIFF_BACKEND_TTL;
     // if we have a constant for the tmp-dir
     if(defined('SHARIFF_BACKEND_TMPDIR'))$tmp["cache"]["cacheDir"]=SHARIFF_BACKEND_TMPDIR;
     // if we do not have a tmp-dir, we use the content dir of WP
     if( empty($tmp["cache"]["cacheDir"]) ){
-      // force a short init because we only need WP core
-      define( 'SHORTINIT', true );
-      // build the wp-load/-config.php path
-      $wp_root_path = dirname( dirname( dirname( dirname( dirname( __FILE__ ) ) ) ) );
-      // include the config
-      include ( $wp_root_path . '/wp-config.php' );         
-      // include wp-load.php file (that loads wp-config.php and bootstraps WP)
-      require( $wp_root_path . '/wp-load.php' );
-      // include for needed untrailingslashit()
-      require( $wp_root_path . '/wp-includes/formatting.php');
       // to avoid conficts with other plugins and actual uploads we use a fixed date in the past
       // month of my birthday would be great ;-) The wp_upload_dir() create the dir if not exists.
       $upload_dir = @wp_upload_dir('1970/01');

--- a/shariff/uninstall.php
+++ b/shariff/uninstall.php
@@ -22,9 +22,7 @@ if (is_multisite()) {
           $users = get_users('role=administrator');
           foreach ($users as $user) { if ( !get_user_meta($user, 'shariff3UU_ignore_notice' )) { delete_user_meta($user->ID, 'shariff3UU_ignore_notice'); } };
           // delete cache dir
-          // $upload_dir = wp_upload_dir();
-          // $cache_dir = $upload_dir['basedir'].'/1970';
-          // shariff_removecachedir( $cache_dir );
+          shariff_removecachedir();
           // switch back to main
           restore_current_blog();
         }
@@ -38,20 +36,25 @@ if (is_multisite()) {
     $users = get_users('role=administrator');
     foreach ($users as $user) { if ( !get_user_meta($user, 'shariff3UU_ignore_notice' )) { delete_user_meta($user->ID, 'shariff3UU_ignore_notice'); } };
     // delete cache dir
-    // $upload_dir = wp_upload_dir();
-    // $cache_dir = $upload_dir['basedir'].'/1970';
-    // shariff_removecachedir( $cache_dir );
+    shariff_removecachedir();
 }
 
-/* Helper function to delete cache directory */
-function shariff_removecachedir($directory){
-# ritze: Das is mir zu gefaehrlich. Wenn jemand nen Archiv aufgebaut 
-# hat, loeschen wir ihm damit vielleicht wichtige Files. Erstmal 
-# unschaedlich gemacht, bis mir nen besseres Verzeichnis einfaellt.
-return;
-  foreach(glob("{$directory}/*") as $file) {
-    if(is_dir($file)) shariff_removecachedir($file);
-    else @unlink($file);
+/* Delete cache directory */
+function shariff_removecachedir(){
+  $upload_dir = wp_upload_dir();
+  $cache_dir = $upload_dir['basedir'].'/1970/01';
+  $cache_dir2 = $upload_dir['basedir'].'/1970';
+  shariff_removefiles( $cache_dir );
+  // Remove /1970/01 and /1970 if they are empty
+  @rmdir($cache_dir);
+  @rmdir($cache_dir2);
+}
+
+/* Helper function to delete .dat files that begin with "Shariff" and empty folders that also start with "Shariff" */
+function shariff_removefiles($directory){
+  foreach(glob("{$directory}/Shariff*") as $file) {
+    if(is_dir($file)) shariff_removefiles($file);
+    else if(substr($file, -4) == '.dat') @unlink($file);
   }
   @rmdir($directory);
 }


### PR DESCRIPTION
Wenn man Konstanten in der wp-config.php nutzen will, sollte man sie
auch laden, bevor man sie verwendet ;) Fix u.a. für
https://wordpress.org/support/topic/leere-ordner-in-uploads197001 und
eigentlich für jeden, der nicht das upload-Verzeichnis nutzen möchte.