### PR TITLE
fix-css-list-style-type

### DIFF
--- a/src/style/shariff-layout.less
+++ b/src/style/shariff-layout.less
@@ -29,7 +29,7 @@
 		justify-content: flex-start;
         padding: 0;
         margin: 0;
-        list-style: none;
+        li { list-style-type: none; }
     }
     ul { li::before { content: normal !important; } }
     li {


### PR DESCRIPTION
Fix für Seiten, die meinen unbedingt für alle li einen list-style-type
zu setzen, anstatt nur da, wo sie es brauchen.