### PR TITLE
fix-doppelte-twitter-fenster

### DIFF
--- a/src/js/services/twitter.js
+++ b/src/js/services/twitter.js
@@ -1,3 +1,5 @@
+/* globals window */
+
 'use strict';
 
 var url = require('url');
@@ -17,7 +19,14 @@ var abbreviateText = function(text, length) {
 };
 
 module.exports = function(shariff) {
-    var shareUrl = url.parse('https://twitter.com/intent/tweet', true);
+    var shareUrl;
+    // Fix für Seiten auf denen die Twitter-Skripte geladen sind -> verwende veralteten Share-Link
+    if (window.twttr) { 
+        shareUrl = url.parse('https://twitter.com/share', true);
+    }
+    else {
+        shareUrl = url.parse('https://twitter.com/intent/tweet', true);
+    }
 
     var title = shariff.getMeta('DC.title');
     var creator = shariff.getMeta('DC.creator');


### PR DESCRIPTION
Ganz toller Fix für doppelte Twitter-Fenster, wenn andere
Twitter-Plugins geladen sind (Feeds, etc.). Verwendet in diesem Fall
den veralteten Share-Link, der nicht die click-events aus der
http://platform.twitter.com/widgets.js auslöst. Bessere Fixes gerne
akzeptiert. Mir fällt nix mehr ein.