### PR TITLE
fix mailform comment

### DIFF
--- a/shariff/readme.txt
+++ b/shariff/readme.txt
@@ -147,8 +147,10 @@ A: mail was replaced with mailform to provide an easier way of distinguishing be
 A: Yes, take a look at the Mail Form tab on the plugin options page.
 
 == Changelog ==
+
 = 2.3.2 =
-- add frensh (thanks Charlotte) and italian (thanks Pier) translations to admin menue
+- add French (thanks Charlotte) and Italian (thanks Pier) translations
+- improve screen reader compatibility
 - fix: prefill mail_comment in case of an error
 - fix: do not send more than 1 email as CC. Use a new mail for all recipients.
 - fix: fallback to English at the email form only if language is not supported by this plugin

--- a/shariff/shariff.php
+++ b/shariff/shariff.php
@@ -1464,6 +1464,7 @@ function sharif3UUprocSentMail( $content ) {
 			 } elseif ( ! empty( $mf_content_from ) ) 					{ add_filter( 'wp_mail_from_name', 'set2_wp_mail_from_name' );
 			 } elseif ( ! empty( $GLOBALS["shariff3UU_mailform"]["mail_sender_name"] ) ) 	{ add_filter( 'wp_mail_from_name', 'set3_wp_mail_from_name' );
 			 } else 									{ add_filter( 'wp_mail_from_name', 'set4_wp_mail_from_name' ); }
+			 // also hier drüber haste jetzt zwar 7 Zeilen eingespart, aber du kannst mir nicht erzählen, dass das jetzt besser zu lesen ist ;-)
 
 			 // Achtung: NICHT die Absenderadresse selber umschreiben! 
 			 // Das fuehrt bei allen sauber aufgesetzten Absender-MTAs zu Problemen mit SPF und/oder DKIM.

--- a/shariff/shariff.php
+++ b/shariff/shariff.php
@@ -95,11 +95,11 @@ else {
 function shariff3UU_update() {
 
 	/******************** ADJUST VERSION ********************/
-	$code_version = "2.3.1"; // set code version - needs to be adjusted for every new version!
+	$code_version = "2.3.2"; // set code version - needs to be adjusted for every new version!
 	/******************** ADJUST VERSION ********************/
 
 	// do we want to display an admin notice after the update?
-	$do_admin_notice = true;
+	$do_admin_notice = false;
 
 	// check if the installed version is older than the code version
 	if( empty( $GLOBALS["shariff3UU"]["version"] ) || ( isset( $GLOBALS["shariff3UU"]["version"] ) && version_compare( $GLOBALS["shariff3UU"]["version"], $code_version ) == '-1' ) ) {
@@ -1432,11 +1432,11 @@ function sharif3UUprocSentMail( $content ) {
 	// optional auf eingeloggte User beschraenken, dann aber auch nicht allgemein anzeigen
 
 	// get vars from form
-	$mf_nonce		= sanitize_text_field( $_REQUEST['shariff_mf_nonce'] );
-	$mf_content_mailto	= sanitize_text_field( $_REQUEST['mailto'] );
-	$mf_content_from	= sanitize_text_field( $_REQUEST['from'] );
-	$mf_content_sender	= sanitize_text_field( $_REQUEST['sender'] );
-	$mf_lang		= sanitize_text_field( $_REQUEST['lang'] );
+	$mf_nonce           = sanitize_text_field( $_REQUEST['shariff_mf_nonce'] );
+	$mf_content_mailto  = sanitize_text_field( $_REQUEST['mailto'] );
+	$mf_content_from    = sanitize_text_field( $_REQUEST['from'] );
+	$mf_content_sender  = sanitize_text_field( $_REQUEST['sender'] );
+	$mf_lang            = sanitize_text_field( $_REQUEST['lang'] );
 
 	// clean up comments
 	$mf_comment_content = $_REQUEST['mail_comment'] ;

--- a/shariff/shariff.php
+++ b/shariff/shariff.php
@@ -1436,7 +1436,6 @@ function sharif3UUprocSentMail( $content ) {
 	$mf_content_mailto	= sanitize_text_field( $_REQUEST['mailto'] );
 	$mf_content_from	= sanitize_text_field( $_REQUEST['from'] );
 	$mf_content_sender	= sanitize_text_field( $_REQUEST['sender'] );
-	$mf_content_mail_comment= sanitize_text_field( $_REQUEST['mail_comment'] );
 	$mf_lang		= sanitize_text_field( $_REQUEST['lang'] );
 
 	// clean up comments
@@ -1452,7 +1451,7 @@ function sharif3UUprocSentMail( $content ) {
 		$error['mf_content_mailto']       = $mf_content_mailto;
 		$error['mf_content_from']         = $mf_content_from;
 		$error['mf_content_sender']       = $mf_content_sender;
-		$error['mf_content_mail_comment'] = $mf_content_mail_comment;
+		$error['mf_content_mail_comment'] = $mf_comment_content;
 
 		// rate limiter
 		$wait = limitRemoteUser();

--- a/shariff/updates.php
+++ b/shariff/updates.php
@@ -152,6 +152,9 @@ if ( version_compare( $GLOBALS["shariff3UU"]["version"], '2.2.5' ) == '-1' ) {
 		delete_option( 'shariff3UU' );
 	}
 
+	// display update notice
+	$do_admin_notice = true;
+
 	// update version
 	$GLOBALS["shariff3UU"]["version"] = '2.3.0';
 }

--- a/src/js/shariff.js
+++ b/src/js/shariff.js
@@ -230,6 +230,10 @@ Shariff.prototype = {
             }
             $shareLink.attr('title', self.getLocalized(service, 'title'));
 
+            // add attributes for screen readers
+            $shareLink.attr('role', 'button');
+            $shareLink.attr('aria-label', self.getLocalized(service, 'title'));
+
             $li.append($shareLink);
 
             $buttonList.append($li);


### PR DESCRIPTION
- Das sanitize_text_field beim comment ist ja Quatsch, weil wir das zwei Zeilen
drunter mit wp_kses säubern (was hier auch besser ist, weil z.B. Absätze erhalten bleiben).
- code version erhöht
- admin update notice nur zeigen bei Update von < 2.3.0 (müssen die Leute ja net nerven, wenn sie von 2.3.0 oder 2.3.1 kommen)
- verbessert die Kompatibilität mit Screen Readern
- bitte, wenn es irgendwie die Gewohnheit zulässt, nutze keine tabs für code Ausrichtungen innerhalb einer Zeile, das sieht auf den Github-Diffs immer fürchterlich aus und ist viel schwerer zu lesen.