### PR TITLE
fix-facebookid

### DIFF
--- a/shariff/backend/services/facebook.php
+++ b/shariff/backend/services/facebook.php
@@ -4,8 +4,8 @@
 
 // if we have a fb id and secret, use it
 if ( isset( $shariff3UU_advanced['fb_id'] ) && isset( $shariff3UU_advanced['fb_secret'] ) ) {
-	$fb_app_id = absint( $shariff3UU_advanced['fb_id'] );
-	$fb_app_secret = sanitize_text_field( $shariff3UU_advanced['fb_secret'] );
+	$fb_app_id = $shariff3UU_advanced['fb_id'];
+	$fb_app_secret = $shariff3UU_advanced['fb_secret'];
 	// get fb access token
 	$fb_token = sanitize_text_field( wp_remote_retrieve_body( wp_remote_get( 'https://graph.facebook.com/oauth/access_token?client_id=' .  $fb_app_id . '&client_secret=' . $fb_app_secret . '&grant_type=client_credentials' ) ) );
 	// use token to get share counts

--- a/shariff/readme.txt
+++ b/shariff/readme.txt
@@ -147,6 +147,9 @@ A: Yes, take a look at the Mail Form tab on the plugin options page.
 
 == Changelog ==
 
+= 3.1.2 =
+- fix Facebook ID on 32-bit systems
+
 = 3.1.1 =
 - make admin help compatible to the new backend
 

--- a/shariff/shariff.php
+++ b/shariff/shariff.php
@@ -3,7 +3,7 @@
  * Plugin Name: Shariff Wrapper
  * Plugin URI: http://www.3uu.org/plugins.htm
  * Description: This is a wrapper to Shariff. It enables shares with Twitter, Facebook ... on posts, pages and themes with no harm for visitors privacy.
- * Version: 3.1.1
+ * Version: 3.1.2
  * Author: 3UU, JP
  * Author URI: http://www.DatenVerwurstungsZentrale.com/
  * License: http://opensource.org/licenses/MIT
@@ -103,7 +103,7 @@ else {
 function shariff3UU_update() {
 
 	/******************** ADJUST VERSION ********************/
-	$code_version = "3.1.1"; // set code version - needs to be adjusted for every new version!
+	$code_version = "3.1.2"; // set code version - needs to be adjusted for every new version!
 	/******************** ADJUST VERSION ********************/
 
 	// do we want to display an admin notice after the update?


### PR DESCRIPTION
Da muss man einmal drauf kommen. Die Facebook ID besteht nur aus
Zahlen. Also warum nicht einmal checken, ob das auch wirklich der Fall
ist. Sicher ist sicher und so. Super Idee. Da wundert man sich, warum
es bei einem selbst funktioniert, bei der großen Masse auch, aber bei
so ein paar Leute, da geht es irgendwie nicht und Facebook meldet so
einen „Es ist was passiert.“-Fehler. Bis man darauf kommt, dass man
beim check ja logischerweise das Ganze zu nem Integer macht. Das ist
auch nicht schlimm, es sei denn man befindet sich noch auf einem 32-bit
gammel Server, dann ist bei 2 Billionen Schluss und damit passt die
ganze schöne ID da leider nicht rein.