### PR TITLE
update-status-section

### DIFF
--- a/shariff/backend/services/facebook.php
+++ b/shariff/backend/services/facebook.php
@@ -28,6 +28,9 @@ else {
 if ( isset( $facebook_json['data'] ) && isset( $facebook_json['data'][0] ) && isset( $facebook_json['data'][0]['total_count'] ) ) {
 	$share_counts['facebook'] = intval( $facebook_json['data'][0]['total_count'] );
 }
+elseif ( isset($facebook_json['data'] ) && isset( $facebook_json['data'][0] ) && isset( $facebook_json['data'][0]['share_count'] ) ) {
+	$share_counts['facebook'] = intval( $facebook_json['data'][0]['share_count'] );
+}
 elseif ( isset($facebook_json['share'] ) && isset( $facebook_json['share']['share_count'] ) ) {
 	$share_counts['facebook'] = intval( $facebook_json['share']['share_count'] );
 }

--- a/shariff/backend/services/googleplus.php
+++ b/shariff/backend/services/googleplus.php
@@ -30,8 +30,8 @@ $google_post_options = array(
 );
 
 // fetch counts
-$google = sanitize_text_field( wp_remote_retrieve_body( wp_remote_post( 'https://clients6.google.com/rpc?key=AIzaSyCKSbrvQasunBoV16zDH9R33D88CeLr9gQ', $google_post_options ) ) );
-$google_json = json_decode( $google, true );
+$googleplus = sanitize_text_field( wp_remote_retrieve_body( wp_remote_post( 'https://clients6.google.com/rpc?key=AIzaSyCKSbrvQasunBoV16zDH9R33D88CeLr9gQ', $google_post_options ) ) );
+$google_json = json_decode( $googleplus, true );
 
 // store results, if we have some
 if ( isset( $google_json['result']['metadata']['globalCounts']['count'] ) ) {


### PR DESCRIPTION
Status-Bereich liefert nun bei einem Fehler bei einem der Services den
entsprechenden Output, den der Service zurückgab (natürlich nicht bei
deaktivierten Services). Zum Testen inkludiert er die entsprechenden
Files vom Backend, so dass wir keine doppelten Dinge pflegen müssen.

Bei einem neuen Service braucht man nur das $services-Array erweitern.
Flattr hab ich hier ebenfalls erst einmal rausgelassen, weil die API
immer noch down ist.

Möchte man beim Entwicklen einmal sehen, was die ganzen Services
zurückliefen, dann braucht man nur in Zeile 1243 der shariff.php das !
bei if ( ! isset ( $share_counts[ $service ] ) ) { entfernen und er
liefert alle Ergebnisse aus. Kann u.U. mal interessant sein, falls ein
Dienst seine API verändert.