### PR TITLE
Add headline before cpt list

### DIFF
--- a/shariff/admin/admin_menu.php
+++ b/shariff/admin/admin_menu.php
@@ -402,18 +402,6 @@ function shariff3UU_multiplecheckbox_add_after_render() {
 	if ( isset( $GLOBALS["shariff3UU_basic"]["add_after"]["pages"] ) ) echo checked( $GLOBALS["shariff3UU_basic"]["add_after"]["pages"], 1, 0 );
 	echo ' value="1">' . __('Pages', 'shariff3UU') . '</p>';
 
-	// choose after which custom post types to add
-	$post_types = get_post_types(array('_builtin' => FALSE));
-	array_walk($post_types, function ($cpt) {
-		$object = get_post_type_object($cpt);
-		printf(
-			'<p><input type="checkbox" name="shariff3UU_basic[add_after][%s]" %s value="1"/>%s</p>',
-			$cpt,
-			isset($GLOBALS['shariff3UU_basic']['add_after'][$cpt]) ? checked($GLOBALS['shariff3UU_basic']['add_after'][$cpt], 1, 0) : '',
-			$object->labels->singular_name	// this should already be localized
-		);
-	});
-
 	// add after all bbpress replies
 	echo '<p><input type="checkbox" name="shariff3UU_basic[add_after][bbp_reply]" ';
 	if ( isset( $GLOBALS["shariff3UU_basic"]["add_after"]["bbp_reply"] ) ) echo checked( $GLOBALS["shariff3UU_basic"]["add_after"]["bbp_reply"], 1, 0 );
@@ -423,6 +411,21 @@ function shariff3UU_multiplecheckbox_add_after_render() {
 	echo '<p><input type="checkbox" name="shariff3UU_basic[add_after][excerpt]" ';
 	if ( isset( $GLOBALS["shariff3UU_basic"]["add_after"]["excerpt"] ) ) echo checked( $GLOBALS["shariff3UU_basic"]["add_after"]["excerpt"], 1, 0 );
 	echo ' value="1">' . __('Excerpt', 'shariff3UU') . '</p>';
+
+	// add after custom post types - choose after which to add
+	$post_types = get_post_types( array( '_builtin' => FALSE ) );
+	if ( isset( $post_types ) && is_array( $post_types ) && ! empty( $post_types ) ) {
+		echo '<p>Custom Post Types:</p>';
+	};
+	array_walk( $post_types, function ( $cpt ) {
+		$object = get_post_type_object( $cpt );
+		printf(
+			'<p><input type="checkbox" name="shariff3UU_basic[add_after][%s]" %s value="1">%s</p>',
+			$cpt,
+			isset( $GLOBALS['shariff3UU_basic']['add_after'][$cpt] ) ? checked( $GLOBALS['shariff3UU_basic']['add_after'][$cpt], 1, 0 ) : '',
+			$object->labels->singular_name	// this should already be localized <- not always, but there is no way to know, so we have to accept the language mixup
+		);
+	} );
 }
 
 // add before

--- a/shariff/backend/services/facebook.php
+++ b/shariff/backend/services/facebook.php
@@ -3,15 +3,15 @@
 // Facebook
 
 // if we have a fb id and secret, use it
-if ( isset( $shariff3UU_advanced['fb_id'] ) && isset( $shariff3UU_advanced['fb_secret'] ) ) {
+if ( isset( $shariff3UU_statistic['fb_id'] ) && isset( $shariff3UU_statistic['fb_secret'] ) ) {
 	// on 32-bit PHP the constant is 4 and we have to disable the check because the id is too long
 	if ( ( defined( PHP_INT_SIZE ) && PHP_INT_SIZE === '4' ) || ! defined( PHP_INT_SIZE ) ) {
-		$fb_app_id = $shariff3UU_advanced['fb_id'];
+		$fb_app_id = $shariff3UU_statistic['fb_id'];
 	}
 	else {
-		$fb_app_id = absint( $shariff3UU_advanced['fb_id'] );
+		$fb_app_id = absint( $shariff3UU_statistic['fb_id'] );
 	}
-	$fb_app_secret = sanitize_text_field( $shariff3UU_advanced['fb_secret'] );
+	$fb_app_secret = sanitize_text_field( $shariff3UU_statistic['fb_secret'] );
 	// get fb access token
 	$fb_token = sanitize_text_field( wp_remote_retrieve_body( wp_remote_get( 'https://graph.facebook.com/oauth/access_token?client_id=' .  $fb_app_id . '&client_secret=' . $fb_app_secret . '&grant_type=client_credentials' ) ) );
 	// use token to get share counts

--- a/shariff/readme.txt
+++ b/shariff/readme.txt
@@ -191,6 +191,7 @@ fixed in the future - if we have time to spend or you provide us with a lot of "
 
 = 3.3.2 =
 - improve/extend handling of custom post types
+- fix Facebook ID call
 
 = 3.3.1 =
 - fix ttl setting on statistic tab

--- a/shariff/shariff.php
+++ b/shariff/shariff.php
@@ -568,9 +568,8 @@ function shariffPosts( $content ) {
 			$custom_types = array_keys( $all_custom_post_types );
 			// type of current post
 			$current_post_type = get_post_type();
-
 			// add shariff, if custom type and option checked in the admin menu
-			if (isset($shariff3UU['add_after'][$current_post_type]) && $shariff3UU['add_after'][$current_post_type] == 1) {
+			if ( isset( $shariff3UU['add_after'][$current_post_type] ) && $shariff3UU['add_after'][$current_post_type] == 1 ) {
 				$content .= buildShariffShorttag();
 			}
 		}


### PR DESCRIPTION
The list with the custom post types can get very, very long. I had up
to 20 cpts in one example. Therefore we should put them a) at the end
of the list and b) give them a small headline, so people know where
this stuff is coming from.