### PR TITLE
WP-CLI: make updates.php working for WP-CLI

### DIFF
--- a/shariff/shariff.php
+++ b/shariff/shariff.php
@@ -18,14 +18,15 @@ if ( ! class_exists( 'WP' ) ) {
 	die();
 }
 
+// Force the creation as a global variable in order to work with WP-CLI.
+global $shariff3uu_basic, $shariff3uu_design, $shariff3uu_advanced, $shariff3uu_statistic, $shariff3uu;
+
 // Get options (needed for front- and backend).
 $shariff3uu_basic     = (array) get_option( 'shariff3uu_basic' );
 $shariff3uu_design    = (array) get_option( 'shariff3uu_design' );
 $shariff3uu_advanced  = (array) get_option( 'shariff3uu_advanced' );
 $shariff3uu_statistic = (array) get_option( 'shariff3uu_statistic' );
 
-// Force the creation as a global variable in order to work with WP-CLI.
-global $shariff3uu;
 $shariff3uu = array_merge( $shariff3uu_basic, $shariff3uu_design, $shariff3uu_advanced, $shariff3uu_statistic );
 
 /**


### PR DESCRIPTION
If using WP-CLI, plugin files do not get imported in global scope. All variables that would be created globally by default in normal execution will not get created as global variables unless you force them do be. [See the docs](https://make.wordpress.org/cli/handbook/implementation-details/#wordpress-is-loaded-inside-of-a-function).

You already do this with `$shariff3uu` but missed the four other variables `$shariff3uu_{basic,design,advanced,statistic}`. `updates.php` requires them to be global.

If you just update the plugin with WP-CLI `updates.php` will not get executed. (Since it is hooked in `admin_init`). But if you then call another WP-CLI command that does execute the `admin_init` hook (there are some, that do, the default ones do not) `updates.php` gets executed and cleans out all saved options.

This pull request just forces the four other setting variables to be global, too.

BTW: Shouldn't `shariff3uu_update` be better hooked into `init` not `admin_init`? Otherwise, if you update the plugin with `wp plugin update shariff` and never go to the WordPress admin `updates.php` never gets executed and the frontend might not have an up to date `$shariff3uu` to work with.  