### PR TITLE
Release 4.6.4 + 4.6.5

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,11 @@ If you need any help or have specific questions regarding development and contri
 
 ## Changelog
 
+= 4.6.5 =
+- updated to Facebook Graph API v6.0
+- fixed minor bug
+- tested for WordPress 5.4
+
 = 4.6.4 =
 - fixed the settings link on the plugin overview page for certain environments (thanks to @midgard)
 - updated to Facebook Graph API v5.0

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,13 @@ If you need any help or have specific questions regarding development and contri
 
 ## Changelog
 
+= 4.6.4 =
+- fixed the settings link on the plugin overview page for certain environments (thanks to @midgard)
+- updated to Facebook Graph API v5.0
+- updated the WhatsApp link to swap url and title for a working image preview
+- removed nofollow from the info button
+- remvoed Xing share counts due to Xing disabling the API
+
 = 4.6.3 =
 - updated the WhatsApp share link to work with all devices again (thanks to @hanshansenxxx)
 - updated to Facebook Graph API v3.3

--- a/shariff/admin/admin-menu.php
+++ b/shariff/admin/admin-menu.php
@@ -12,7 +12,7 @@ if ( ! class_exists( 'WP' ) ) {
 }
 
 // Set services that have a share count API / backend.
-$shariff3uu_services_backend = array( 'facebook', 'twitter', 'pinterest', 'xing', 'reddit', 'tumblr', 'vk', 'addthis', 'odnoklassniki', 'buffer' );
+$shariff3uu_services_backend = array( 'facebook', 'twitter', 'pinterest', 'reddit', 'tumblr', 'vk', 'addthis', 'odnoklassniki', 'buffer' );
 
 // Adds the actions for the admin page.
 add_action( 'admin_menu', 'shariff3uu_add_admin_menu' );

--- a/shariff/changelog.txt
+++ b/shariff/changelog.txt
@@ -2,6 +2,13 @@
 
 == Changelog ==
 
+= 4.6.4 =
+- fixed the settings link on the plugin overview page for certain environments (thanks to @midgard)
+- updated to Facebook Graph API v5.0
+- updated the WhatsApp link to swap url and title for a working image preview
+- removed nofollow from the info button
+- remvoed Xing share counts due to Xing disabling the API
+
 = 4.6.3 =
 - updated the WhatsApp share link to work with all devices again (thanks to @hanshansenxxx)
 - updated to Facebook Graph API v3.3

--- a/shariff/readme.txt
+++ b/shariff/readme.txt
@@ -3,8 +3,8 @@ Contributors: starguide, 3UU
 Tags: Shariff, GDPR, DSGVO, share buttons, sharing
 Requires at least: 4.9
 Requires PHP: 7.0
-Tested up to: 5.2
-Stable tag: 4.6.3
+Tested up to: 5.3
+Stable tag: 4.6.4
 License: MIT
 License URI: http://opensource.org/licenses/mit
 
@@ -36,97 +36,89 @@ To enable it for all posts please check the options in the plugin settings.
 
 == Frequently Asked Questions ==
 
-= Q: Can I use the Shariff buttons in my theme? =
-A: Yes. Simply use the shortcode function `do_shortcode('[shariff]')`.
+= Can I use the Shariff buttons in my theme? =
+Yes. Simply use the shortcode function:
+<code>do_shortcode('[shariff]')</code>
 You can use all options of the shorttag as described on the help tab in the plugin settings.
 
-= Q: Can I use the total amount of shares in my theme? =
-A: Yes. You can use `do_shortcode('[shariff services="totalnumber"]')` to simply output the total amount of shares for a post in the loop. It will return the number itself wrapped in a `<span class="shariff-totalnumber"></span>` in order for the shariff.js to update the count. Also only cached data is used, in order to not slow down your site.
+= Can I use the total amount of shares in my theme? =
+Yes. You can use <code>do_shortcode('[shariff services="totalnumber"]')</code> to simply output the total amount of shares for a post in the loop. It will return the number itself wrapped in a <code><span class="shariff-totalnumber"></span></code> in order for the shariff.js to update the count. Also only cached data is used, in order to not slow down your site.
 
-= Q: Is there an action hook to use the share counts every time they get updated? =
-A: Yes. You can use
-`function your_awesome_function( $share_counts ) {
+= Is there an action hook to use the share counts every time they get updated? =
+Yes. You can use
+<code>function your_awesome_function( $share_counts ) {
    // $share_counts is an array including all enabled services, the timestamp of the update and the url of the post.
    // do stuff
 } 
-add_action( 'shariff_share_counts', 'your_awesome_function' );` 
+add_action( 'shariff_share_counts', 'your_awesome_function' );</code>
 WARNING: This hook will get called A LOT. So be sure you know what you are doing.
 
-= Q: How can I configure the widget? =
-A: It uses the same options that have been configured on the plugin options page. However, you can put in a shorttag that overwrites the default options. It has the same format as you use in posts. Take a look at the help section of the plugin options page for more information.
+= How can I configure the widget? =
+It uses the same options that have been configured on the plugin options page. However, you can put in a shorttag that overwrites the default options. It has the same format as you use in posts. Take a look at the help section of the plugin options page for more information.
 
-= Q: Can I change the options on a single post? =
+= Can I change the options on a single post? =
 A: Yes. You can change all options using the shorttag in the Shariff meta box on the right side of the post edit screen.
 
-= Q: Why are shares not listed? =
+= Why are shares not listed? =
 A: Shariff tries to protect the privacy of your visitors. In order to do this, the statistics have to be requested by your server, so social networks only see a request of your server and not from your visitor. However, we do not know, if you want this. Therefore it is not enabled by default.
 
-= Q: How can I show the share counts? =
-A: Enable it on the plugin options page in general or add `backend="on"` to the shariff shorttag in your post.
+= How can I show the share counts? =
+Enable it on the plugin options page in general or add <code>backend="on"</code> to the shariff shorttag in your post.
 
-= Q: I still do not see share counts =
-A: Please have a look at the status tab on the plugin options page. It states whether share counts are enabled and if there is a problem with a service. Please also keep in mind that the plugin has a minimum refresh time of 60 seconds and that each service has their own cache as well.
+= I still do not see share counts =
+Please have a look at the status tab on the plugin options page. It states whether share counts are enabled and if there is a problem with a service. Please also keep in mind that the plugin has a minimum refresh time of 60 seconds and that each service has their own cache as well.
 
-= Q: Why can't I change the TTL to a smaller / bigger value? =
-A: The time to live (TTL) value determines, if a share count of a post or page gets refreshed when someone visits this specific page / post of your blog. Too small values create too much useless traffic, too high values negate the goal of motivating visitors to also share a post. The value can be adjusted between 60 and 7200 seconds. Keep in mind, the actual lifespan depends on the age of the post as well.
+= Why can't I change the TTL to a smaller / bigger value? =
+The time to live (TTL) value determines, if a share count of a post or page gets refreshed when someone visits this specific page / post of your blog. Too small values create too much useless traffic, too high values negate the goal of motivating visitors to also share a post. The value can be adjusted between 60 and 7200 seconds. Keep in mind, the actual lifespan depends on the age of the post as well.
 
-= Q: I get the Facebook API error message "request limit reached"! =
-A: Facebook has a rate limit of 600 requests per 600 seconds per IP address. Especially in shared hosting environments many domains share the same IP address and therefore the same limit. To avoid this you can try to raise the TTL value or provide a Facebook App ID and Secret. Google "facebook app id secret" will provide many guides on how to get these.
+= How can I change the position of all buttons? =
+Have a look at the alignment options in the admin menu or checkout the style option.
 
-= Q: How can I change the position of all buttons? =
-A: Have a look at the alignment options in the admin menu or checkout the 
-style option.
+= How can I change the design? =
+Have a look at the parameters "theme", "orientation" and "buttonsize". They work mostly like the original code parameters that are explained at http://heiseonline.github.io/shariff/ Or you can have a look at the test page at https://shariff.3uu.net/shariff-sample-page-with-all-options to get an overview. But please be warned: This is a test page! It is possible that you find features that are only provided in the development version. Use it only to get an impression of the design options.
 
-= Q: How can I change the design? =
-A: Have a look at the parameters "theme", "orientation" and "buttonsize". They work mostly like the original code parameters that are explained at http://heiseonline.github.io/shariff/ Or you can have a look at the test page at http://shariff.3uu.net/shariff-sample-page-with-all-options to get an
-overview. But please be warned: This is a test page! It is possible that you find features that are only provided in the development version. Use it only to get an impression of the design options.
-
-= Q: How can I change the design of a single button? =
+= How can I change the design of a single button? =
 A: If you are a CSS guru please feel free to modify the css file. But of course this is a bad idea, because all changes will be destroyed with the next update! Instead take a look at the style and class attribute of the shorttag. If you put in any value it will create a DIV container with the ID "ShariffSC" around the buttons. If you are really a CSS guru you will know what does the magic from here on out. ;-)
 
-= Q: I want the buttons to stay fixed while scrolling! =
-A: No problem. Just use the style attribute to add some CSS to the shorttag. For example in a widget (adjust the width as needed):
-`[shariff style="position:fixed;width:250px"]`
+= I want the buttons to stay fixed while scrolling! =
+No problem. Just use the style attribute to add some CSS to the shorttag. For example in a widget (adjust the width as needed):
+<code>[shariff style="position:fixed;width:250px"]</code>
 Of course you can use all other options in that shorttag as well. It also works with the CSS style option on the plugins design options page, if you really want this applied to all buttons on your page.
 
-= Q: I want a horizontal line above my Shariff buttons! =
-A: You can use the headline option on the design tab. For example, enter the following code to create a horizontal line and a headline:
-`<hr style='margin:20px 0'><p>Please share this post:</p>`
+= I want a horizontal line above my Shariff buttons! =
+You can use the headline option on the design tab. For example, enter the following code to create a horizontal line and a headline:
+<code><hr style='margin:20px 0'><p>Please share this post:</p></code>
 
-= Q: I want a different or no headline in a single widget, post or page! =
-A: Use the headline attribute to add or remove it. For example, you can use the following shorttag to remove a headline set on the plugins options page in a single widget:
-`[shariff headline=""]`
+= I want a different or no headline in a single widget, post or page! =
+Use the headline attribute to add or remove it. For example, you can use the following shorttag to remove a headline set on the plugins options page in a single widget:
+<code>[shariff headline=""]</code>
 Of course you can use all other options in that shorttag as well.
 
-= Q: Can I add [shariff] on all posts? =
-A: Yes, check out the plugin options. 
+= Can I add <code>[shariff]</code> on all posts? =
+Yes, check out the plugin options.
 
-= Q: But I want to hide it on a single post! =
-A: Do you really know what you want? ;-) However, it is possible. Write anywhere in your post "hideshariff". It will be removed and Shariff will not be added. You can also use "/hideshariff" to write "hideshariff" in your post. You might also want to take a look at the Shariff meta box on the right side of your post edit screen.
+= QBut I want to hide it on a single post! =
+Do you really know what you want? ;-) However, it is possible. Write anywhere in your post "hideshariff". It will be removed and Shariff will not be added. You can also use "/hideshariff" to write "hideshariff" in your post. You might also want to take a look at the Shariff meta box on the right side of your post edit screen.
 
-= Q: What are the differences between the two Shariff plugins? =
-A: One is developed by us, one by someone else. ;-) The main difference is that this plugin has a few more options and a great support. :-) Neither of the plugins are "official" or directly developed by Heise.
+= Does it work with a CDN? =
+Yes.
 
-= Q: Does it work with a CDN? =
-A: Yes.
+= Pinterest does not show an image! =
+You can add <code>media="http://wwww.example.com/yourImage.png"</code> within the <code>[shariff]</code> shorttag or add it in on the plugin options page - of course with the link to your image.
 
-= Q: Pinterest does not show an image! =
-A: You can add media="http://wwww.example.com/yourImage.png"
-within the [shariff] shorttag or add it in on the plugin options page - of course with the link to your image.
-
-= Q: Can I set a fixed URL to share? =
-A: You can use the "url" parameter within the shortcode
-`[shariff url="http://www.example.com/"]`
+= Can I set a fixed URL to share? =
+You can use the "url" parameter within the shortcode
+<code>[shariff url="http://www.example.com/"]</code>
 This is also available within widgets. However, it is not a good idea to manipulate the URI, because it could mislead your visitors. So you should only use it, if this is really needed and you do really know what you are doing. Therefore it is not available on the plugin options page in general. 
 
-= Q: What happened to the Twitter share counts and what is OpenShareCount? =
-A: Please read: https://www.jplambeck.de/twitter-saveoursharecounts/
+= What happened to the Twitter share counts? =
+Twitter does not offer official share counts anymore. As an alternative, share counts for Twitter can be requested via twitcount.com. You will need to register with them for it to work. Otherwise the count will always be zero.
 
-= Q: The buttons are not correctly being shown on my custom theme! =
-A: Please make sure that wp_footer(); has been added to your theme. For more information please visit: https://codex.wordpress.org/Function_Reference/wp_footer
+= The buttons are not correctly being shown on my custom theme! =
+Please make sure that <code>wp_footer();</code> has been added to your theme. For more information please visit: https://codex.wordpress.org/Function_Reference/wp_footer
 
-= Q: What is the external API feature? =
-A: First of all: Usually you do not need it! The plugin requests all share counts itself. However, there are some reasons to put the backend on another server:
+= What is the external API feature? =
+First of all: Usually you do not need it! The plugin requests all share counts itself. However, there are some reasons to put the backend on another server:
 - avoid requests from you WP server to all the social networks
 - use a more powerful server for the statistic
 - use the original backend implementation of Heise or your own solution
@@ -137,12 +129,12 @@ But please have in mind that there are also some good reasons not to use externa
 - you have to use SHARIFF_FRONTENDS as an array with all your frontend domains to enable the backend or find your own solution
 - we CANNOT provide support for your own implementation
 
-= Q: How can I configure the external API? =
-A: In the statistic settings fill in the URL to the API of the external server. For the WordPress installation on the external server you have to create a "constant" called SHARIFF_FRONTENDS to permit other domains to use it. Please have in mind that you have to fill in all subdomains you want to use! The domains must be defined like this:
-`define( 'SHARIFF_FRONTENDS', 'example.com|www.example.com|blog.example.com|another-domain.com' );`
+= How can I configure the external API? =
+In the statistic settings fill in the URL to the API of the external server. For the WordPress installation on the external server you have to create a "constant" called SHARIFF_FRONTENDS to permit other domains to use it. Please have in mind that you have to fill in all subdomains you want to use! The domains must be defined like this:
+<code>define( 'SHARIFF_FRONTENDS', 'example.com|www.example.com|blog.example.com|another-domain.com' );</code>
 
-= Q: What does "Request external API directly." mean? =
-A: By default, the browser request the share counts from the server your site is running on. If you have entered an external API your server will then request the counts from this external API instead of fetching them itself. Therefore, the external server will only see the IP from your server and not the one from your visitors. If you check this option, the browser of your visitors will instead directly request the share counts from the external API and therefore reveal their IP address to them. This might be faster, but it is less secure. Please also make sure to set the Access-Control-Allow-Origin header right. If your site is available using https, your external API will need to be reached by https as well. Otherwise the request will get blocked for security reasons. All options and features (e.g. the ranking tab) regarding the statistic will only work on the external server.
+= What does "Request external API directly." mean? =
+By default, the browser request the share counts from the server your site is running on. If you have entered an external API your server will then request the counts from this external API instead of fetching them itself. Therefore, the external server will only see the IP from your server and not the one from your visitors. If you check this option, the browser of your visitors will instead directly request the share counts from the external API and therefore reveal their IP address to them. This might be faster, but it is less secure. Please also make sure to set the Access-Control-Allow-Origin header right. If your site is available using https, your external API will need to be reached by https as well. Otherwise the request will get blocked for security reasons. All options and features (e.g. the ranking tab) regarding the statistic will only work on the external server.
 
 = KNOWN BUGS =
 
@@ -151,6 +143,13 @@ These are bugs or unexpected glitches that we know of, but that do not have an i
 - If the first post on the start page is password protected and Shariff is disabled on protected posts, a widget at the end of the loop will not be rendered.
 
 == Changelog ==
+
+= 4.6.4 =
+- fixed the settings link on the plugin overview page for certain environments (thanks to @midgard)
+- updated to Facebook Graph API v5.0
+- updated the WhatsApp link to swap url and title for a working image preview
+- removed nofollow from the info button
+- remvoed Xing share counts due to Xing disabling the API
 
 = 4.6.3 =
 - updated the WhatsApp share link to work with all devices again (thanks to @hanshansenxxx)

--- a/shariff/readme.txt
+++ b/shariff/readme.txt
@@ -3,8 +3,8 @@ Contributors: starguide, 3UU
 Tags: Shariff, GDPR, DSGVO, share buttons, sharing
 Requires at least: 4.9
 Requires PHP: 7.0
-Tested up to: 5.3
-Stable tag: 4.6.4
+Tested up to: 5.4
+Stable tag: 4.6.5
 License: MIT
 License URI: http://opensource.org/licenses/mit
 
@@ -144,12 +144,17 @@ These are bugs or unexpected glitches that we know of, but that do not have an i
 
 == Changelog ==
 
+= 4.6.5 =
+- updated to Facebook Graph API v6.0
+- fixed minor bug
+- tested for WordPress 5.4
+
 = 4.6.4 =
 - fixed the settings link on the plugin overview page for certain environments (thanks to @midgard)
 - updated to Facebook Graph API v5.0
 - updated the WhatsApp link to swap url and title for a working image preview
 - removed nofollow from the info button
-- remvoed Xing share counts due to Xing disabling the API
+- removed Xing share counts due to Xing disabling the API
 
 = 4.6.3 =
 - updated the WhatsApp share link to work with all devices again (thanks to @hanshansenxxx)

--- a/shariff/services/shariff-facebook.php
+++ b/shariff/services/shariff-facebook.php
@@ -70,7 +70,7 @@ if ( isset( $frontend ) && 1 === $frontend ) {
 		// Create the FB access token.
 		$fb_token = $fb_app_id . '|' . $fb_app_secret;
 		// Use the token to get the share counts.
-		$facebook = sanitize_text_field( wp_remote_retrieve_body( wp_remote_get( 'https://graph.facebook.com/v5.0/?access_token=' . $fb_token . '&fields=engagement&id=' . $post_url ) ) );
+		$facebook = sanitize_text_field( wp_remote_retrieve_body( wp_remote_get( 'https://graph.facebook.com/v6.0/?access_token=' . $fb_token . '&fields=engagement&id=' . $post_url ) ) );
 		// Decode the json response.
 		$facebook_json = json_decode( $facebook, true );
 		// Set nofbid in case the page has not yet been crawled by Facebook and no ID is provided.

--- a/shariff/services/shariff-facebook.php
+++ b/shariff/services/shariff-facebook.php
@@ -70,7 +70,7 @@ if ( isset( $frontend ) && 1 === $frontend ) {
 		// Create the FB access token.
 		$fb_token = $fb_app_id . '|' . $fb_app_secret;
 		// Use the token to get the share counts.
-		$facebook = sanitize_text_field( wp_remote_retrieve_body( wp_remote_get( 'https://graph.facebook.com/v3.3/?access_token=' . $fb_token . '&fields=engagement&id=' . $post_url ) ) );
+		$facebook = sanitize_text_field( wp_remote_retrieve_body( wp_remote_get( 'https://graph.facebook.com/v5.0/?access_token=' . $fb_token . '&fields=engagement&id=' . $post_url ) ) );
 		// Decode the json response.
 		$facebook_json = json_decode( $facebook, true );
 		// Set nofbid in case the page has not yet been crawled by Facebook and no ID is provided.

--- a/shariff/services/shariff-whatsapp.php
+++ b/shariff/services/shariff-whatsapp.php
@@ -16,7 +16,7 @@ if ( isset( $frontend ) && 1 === $frontend ) {
 	$service_url = 'https://api.whatsapp.com/send';
 
 	// Build button URL.
-	$button_url = $service_url . '?text=' . $share_title . '%20' . $share_url;
+	$button_url = $service_url . '?text=' . $share_url . '%20' . $share_title;
 
 	// Colors.
 	$main_color      = '#34af23';

--- a/shariff/services/shariff-xing.php
+++ b/shariff/services/shariff-xing.php
@@ -27,7 +27,7 @@ if ( isset( $frontend ) && 1 === $frontend ) {
 	$svg_icon = '<svg width="32px" height="20px" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 32"><path fill="' . $main_color . '" d="M10.7 11.9q-0.2 0.3-4.6 8.2-0.5 0.8-1.2 0.8h-4.3q-0.4 0-0.5-0.3t0-0.6l4.5-8q0 0 0 0l-2.9-5q-0.2-0.4 0-0.7 0.2-0.3 0.5-0.3h4.3q0.7 0 1.2 0.8zM25.1 0.4q0.2 0.3 0 0.7l-9.4 16.7 6 11q0.2 0.4 0 0.6-0.2 0.3-0.6 0.3h-4.3q-0.7 0-1.2-0.8l-6-11.1q0.3-0.6 9.5-16.8 0.4-0.8 1.2-0.8h4.3q0.4 0 0.5 0.3z"/></svg>';
 
 	// Backend available?
-	$backend_available = 1;
+	$backend_available = 0;
 
 	// Button alt label.
 	$button_title_array = array(
@@ -57,31 +57,4 @@ if ( isset( $frontend ) && 1 === $frontend ) {
 		'tr' => 'XING\'ta paylaş',
 		'zh' => '分享至XING',
 	);
-} elseif ( isset( $backend ) && 1 === $backend ) {
-	// Set xing options.
-	$xing_json = array(
-		'url' => $post_url_raw,
-	);
-
-	// Set post options.
-	$xing_post_options = array(
-		'method'      => 'POST',
-		'timeout'     => 5,
-		'redirection' => 5,
-		'httpversion' => '1.0',
-		'blocking'    => true,
-		'headers'     => array( 'content-type' => 'application/json' ),
-		'body'        => wp_json_encode( $xing_json ),
-	);
-
-	// Fetch counts.
-	$xing      = sanitize_text_field( wp_remote_retrieve_body( wp_remote_post( 'https://www.xing.com/spi/shares/statistics', $xing_post_options ) ) );
-	$xing_json = json_decode( $xing, true );
-
-	// Store results, if we have some and record errors, if enabled (e.g. request from the status tab).
-	if ( isset( $xing_json['share_counter'] ) ) {
-		$share_counts['xing'] = intval( $xing_json['share_counter'] );
-	} elseif ( isset( $record_errors ) && 1 === $record_errors ) {
-		$service_errors['xing'] = $xing;
-	}
 }

--- a/shariff/shariff.php
+++ b/shariff/shariff.php
@@ -3,7 +3,7 @@
  * Plugin Name: Shariff Wrapper
  * Plugin URI: https://wordpress.org/plugins-wp/shariff/
  * Description: Shariff provides share buttons that respect the privacy of your visitors and follow the General Data Protection Regulation (GDPR).
- * Version: 4.6.4
+ * Version: 4.6.5
  * Author: Jan-Peter Lambeck & 3UU
  * Author URI: https://wordpress.org/plugins/shariff/
  * License: MIT
@@ -33,7 +33,7 @@ $shariff3uu = array_merge( $shariff3uu_basic, $shariff3uu_design, $shariff3uu_ad
  */
 function shariff3uu_update() {
 	// Adjust code version.
-	$code_version = '4.6.4';
+	$code_version = '4.6.5';
 
 	// Get basic options.
 	$shariff3uu_basic = (array) get_option( 'shariff3uu_basic' );
@@ -1330,8 +1330,9 @@ function shariff3uu_render( $atts ) {
 						$output .= 'noopener ';
 					}
 					if ( 'info' !== $service ) {
-						$output .= 'nofollow"';
+						$output .= 'nofollow';
 					}
+					$output .= '"';
 				}
 				$output .= ' class="shariff-link';
 

--- a/shariff/shariff.php
+++ b/shariff/shariff.php
@@ -3,7 +3,7 @@
  * Plugin Name: Shariff Wrapper
  * Plugin URI: https://wordpress.org/plugins-wp/shariff/
  * Description: Shariff provides share buttons that respect the privacy of your visitors and follow the General Data Protection Regulation (GDPR).
- * Version: 4.6.3
+ * Version: 4.6.4
  * Author: Jan-Peter Lambeck & 3UU
  * Author URI: https://wordpress.org/plugins/shariff/
  * License: MIT
@@ -33,7 +33,7 @@ $shariff3uu = array_merge( $shariff3uu_basic, $shariff3uu_design, $shariff3uu_ad
  */
 function shariff3uu_update() {
 	// Adjust code version.
-	$code_version = '4.6.3';
+	$code_version = '4.6.4';
 
 	// Get basic options.
 	$shariff3uu_basic = (array) get_option( 'shariff3uu_basic' );
@@ -170,7 +170,7 @@ function shariff3uu_meta_links( $links, $file ) {
 	if ( $file === $plugin ) {
 		return array_merge(
 			$links,
-			array( '<a href="' . home_url() . '/wp-admin/options-general.php?page=shariff3uu">' . __( 'Settings', 'shariff' ) . '</a>', '<a href="https://wordpress.org/support/plugin/shariff" target="_blank">' . __( 'Support Forum', 'shariff' ) . '</a>' )
+			array( '<a href="' . site_url() . '/wp-admin/options-general.php?page=shariff3uu">' . __( 'Settings', 'shariff' ) . '</a>', '<a href="https://wordpress.org/support/plugin/shariff" target="_blank">' . __( 'Support Forum', 'shariff' ) . '</a>' )
 		);
 	}
 	return $links;
@@ -1329,7 +1329,9 @@ function shariff3uu_render( $atts ) {
 					if ( 'facebook' !== $service ) {
 						$output .= 'noopener ';
 					}
-					$output .= 'nofollow"';
+					if ( 'info' !== $service ) {
+						$output .= 'nofollow"';
+					}
 				}
 				$output .= ' class="shariff-link';
 


### PR DESCRIPTION
= 4.6.4 =
- fixed the settings link on the plugin overview page for certain environments (thanks to @midgard)
- updated to Facebook Graph API v5.0
- updated the WhatsApp link to swap url and title for a working image preview
- removed nofollow from the info button
- remvoed Xing share counts due to Xing disabling the API