### PR TITLE
Release 4.6.6 and 4.6.7

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,14 @@ If you need any help or have specific questions regarding development and contri
 
 ## Changelog
 
+= 4.6.7 =
+- updated to Facebook Graph API v11.0
+- changed FB request to og_object (thanks to richard67)
+
+= 4.6.6 =
+- Fix sanitize_callback parameter to avoid warnings with api requests
+- tested for 5.7
+
 = 4.6.5 =
 - updated to Facebook Graph API v6.0
 - fixed minor bug

--- a/shariff/changelog.txt
+++ b/shariff/changelog.txt
@@ -2,6 +2,14 @@
 
 == Changelog ==
 
+= 4.6.7 =
+- updated to Facebook Graph API v11.0
+- changed FB request to og_object (thanks to richard67)
+
+= 4.6.6 =
+- Fix sanitize_callback parameter to avoid warnings with api requests
+- tested for 5.7
+
 = 4.6.4 =
 - fixed the settings link on the plugin overview page for certain environments (thanks to @midgard)
 - updated to Facebook Graph API v5.0

--- a/shariff/readme.txt
+++ b/shariff/readme.txt
@@ -2,9 +2,9 @@
 Contributors: starguide, 3UU
 Tags: Shariff, GDPR, DSGVO, share buttons, sharing
 Requires at least: 4.9
-Requires PHP: 7.0
-Tested up to: 5.4
-Stable tag: 4.6.5
+Requires PHP: 7.2
+Tested up to: 5.7.3
+Stable tag: 4.6.7
 License: MIT
 License URI: http://opensource.org/licenses/mit
 
@@ -47,7 +47,8 @@ Yes. You can use <code>do_shortcode('[shariff services="totalnumber"]')</code> t
 = Is there an action hook to use the share counts every time they get updated? =
 Yes. You can use
 <code>function your_awesome_function( $share_counts ) {
-   // $share_counts is an array including all enabled services, the timestamp of the update and the url of the post.
+   // $share_counts is an array including all enabled services, 
+   // the timestamp of the update and the url of the post.
    // do stuff
 } 
 add_action( 'shariff_share_counts', 'your_awesome_function' );</code>
@@ -143,6 +144,14 @@ These are bugs or unexpected glitches that we know of, but that do not have an i
 - If the first post on the start page is password protected and Shariff is disabled on protected posts, a widget at the end of the loop will not be rendered.
 
 == Changelog ==
+
+= 4.6.7 =
+- updated to Facebook Graph API v11.0
+- changed FB request to og_object (thanks to richard67)
+
+= 4.6.6 =
+- Fix sanitize_callback parameter to avoid warnings with api requests
+- tested for 5.7
 
 = 4.6.5 =
 - updated to Facebook Graph API v6.0

--- a/shariff/services/shariff-facebook.php
+++ b/shariff/services/shariff-facebook.php
@@ -70,7 +70,7 @@ if ( isset( $frontend ) && 1 === $frontend ) {
 		// Create the FB access token.
 		$fb_token = $fb_app_id . '|' . $fb_app_secret;
 		// Use the token to get the share counts.
-		$facebook = sanitize_text_field( wp_remote_retrieve_body( wp_remote_get( 'https://graph.facebook.com/v6.0/?access_token=' . $fb_token . '&fields=engagement&id=' . $post_url ) ) );
+		$facebook = sanitize_text_field( wp_remote_retrieve_body( wp_remote_get( 'https://graph.facebook.com/v11.0/?access_token=' . $fb_token . '&fields=og_object%7Bengagement%7D&id=' . $post_url ) ) );
 		// Decode the json response.
 		$facebook_json = json_decode( $facebook, true );
 		// Set nofbid in case the page has not yet been crawled by Facebook and no ID is provided.
@@ -81,14 +81,8 @@ if ( isset( $frontend ) && 1 === $frontend ) {
 	* Stores results - uses engagement (Graph API > 2.12) if it exists, otherwise uses share_count - ordered based on proximity of occurrence.
 	* Records errors, if enabled (e.g. request from the status tab).
 	*/
-	if ( isset( $facebook_json['engagement'] ) && isset( $facebook_json['engagement']['share_count'] ) ) {
-		$share_counts['facebook'] = intval( $facebook_json['engagement']['reaction_count'] ) + intval( $facebook_json['engagement']['comment_count'] ) + intval( $facebook_json['engagement']['share_count'] ) + intval( $facebook_json['engagement']['comment_plugin_count'] );
-	} elseif ( isset( $facebook_json['share'] ) && isset( $facebook_json['share']['share_count'] ) ) {
-		$share_counts['facebook'] = intval( $facebook_json['share']['share_count'] );
-	} elseif ( isset( $facebook_json['data'] ) && isset( $facebook_json['data'][0] ) && isset( $facebook_json['data'][0]['total_count'] ) ) {
-		$share_counts['facebook'] = intval( $facebook_json['data'][0]['total_count'] );
-	} elseif ( isset( $facebook_json['data'] ) && isset( $facebook_json['data'][0] ) && isset( $facebook_json['data'][0]['share_count'] ) ) {
-		$share_counts['facebook'] = intval( $facebook_json['data'][0]['share_count'] );
+	if ( isset( $facebook_json['og_object'] ) && isset( $facebook_json['og_object']['engagement'] ) && isset( $facebook_json['og_object']['engagement']['count'] ) ) {
+		$share_counts['facebook'] = intval( $facebook_json['og_object']['engagement']['count'] );
 	} elseif ( isset( $facebook_json['id'] ) && ! isset( $facebook_json['error'] ) && 1 === $nofbid ) {
 		$share_counts['facebook'] = '0';
 	} elseif ( isset( $record_errors ) && 1 === $record_errors ) {

--- a/shariff/shariff.php
+++ b/shariff/shariff.php
@@ -3,7 +3,7 @@
  * Plugin Name: Shariff Wrapper
  * Plugin URI: https://wordpress.org/plugins-wp/shariff/
  * Description: Shariff provides share buttons that respect the privacy of your visitors and follow the General Data Protection Regulation (GDPR).
- * Version: 4.6.5
+ * Version: 4.6.7
  * Author: Jan-Peter Lambeck & 3UU
  * Author URI: https://wordpress.org/plugins/shariff/
  * License: MIT
@@ -33,7 +33,7 @@ $shariff3uu = array_merge( $shariff3uu_basic, $shariff3uu_design, $shariff3uu_ad
  */
 function shariff3uu_update() {
 	// Adjust code version.
-	$code_version = '4.6.5';
+	$code_version = '4.6.7';
 
 	// Get basic options.
 	$shariff3uu_basic = (array) get_option( 'shariff3uu_basic' );
@@ -192,6 +192,8 @@ function shariff3uu_sanitize_api() {
 		array(
 			'methods'  => 'GET',
 			'callback' => 'shariff3uu_share_counts',
+#https://developer.wordpress.org/rest-api/extending-the-rest-api/routes-and-endpoints/#permissions-callback
+			'permission_callback' => '__return_true',
 			'args'     => array(
 				'url'       => array(
 					'sanitize_callback' => 'esc_url',


### PR DESCRIPTION
= 4.6.7 =
- updated to Facebook Graph API v11.0
- changed FB request to og_object (thanks to richard67)

= 4.6.6 =
- Fix sanitize_callback parameter to avoid warnings with api requests
- tested for 5.7