### PR TITLE
Unify German button text for Linkedin

### DIFF
--- a/shariff/services/shariff-linkedin.php
+++ b/shariff/services/shariff-linkedin.php
@@ -34,7 +34,7 @@ if ( isset( $frontend ) && 1 === $frontend ) {
 		'bg' => 'cподеляне',
 		'cs' => 'sdílet',
 		'da' => 'del',
-		'de' => 'mitteilen',
+		'de' => 'teilen',
 		'en' => 'share',
 		'es' => 'compartir',
 		'fi' => 'Jaa',


### PR DESCRIPTION
While most of the other buttons say "teilen" in German, Linkedin says "mitteilen" for some reason.