### PR TITLE
Allow calls to shariff from AJAX callbacks

### DIFF
--- a/shariff/shariff.php
+++ b/shariff/shariff.php
@@ -886,7 +886,7 @@ function shariff3uu_render( $atts ) {
 	}
 
 	// Stops all further actions if we are on an admin page.
-	if ( is_admin() ) {
+	if ( is_admin() && ! wp_doing_ajax() ) {
 		return null;
 	}
 


### PR DESCRIPTION
After banging my head against the wall while trying to do a `do_shortcode( '[shariff]' )` I finally went looking into the sources and found that it's blocked on admin pages. However, since AJAX calls to `ajax-admin.php` also make `is_admin()` evaluate to true this will not work. Here's a simple one-line fix to allow `shariff3uu_render()` (and therefore the shortcode) to run in AJAX calls.